### PR TITLE
Fixed Kafka integration test

### DIFF
--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -20,13 +20,10 @@ limitations under the License.
 package kafka
 
 import (
-	//	"bufio"
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
-	//	"os"
-
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -58,7 +55,6 @@ func NewKafkaPublisher() *kafkaPublisher {
 func (k *kafkaPublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 
 	// Inserted and modified codes from intelsdi-x/snap-plugin-publisher-file/file/file.go
-
 	logger := log.New()
 	logger.Println("Publishing started")
 	var metrics []plugin.MetricType


### PR DESCRIPTION
Summary of changes:
- removed unused lines in kafka/kafka.go
- fixed integration tests (needed after change the format of published data to JSON)

Tests done:
- integration tests
- unit tests

@cr2025x1 , this is a patch to Your pull request https://github.com/intelsdi-x/snap-plugin-publisher-kafka/pull/19 for which integration tests failed - could You review that and merge it to your branch? Thank You.
